### PR TITLE
Sign with gpg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,4 +126,9 @@ jobs:
           asset_name: "sambaza-${{ github.ref_name }}.aar"
           tag: ${{ github.ref }}
           overwrite: true
+      - name: publish to Maven
+        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
+        run: |
+            echo -n "${{ secrets.MAVEN_SIGNING_KEY }}" | base64 --decode | gpg --import
+            ./gradlew -PSKYWAY_RELEASE_STORE_FILE="/tmp/keystore.jks" -PSKYWAY_RELEASE_STORE_PASSWORD="${{ secrets.STORE_PASSWORD }}" -PSKYWAY_RELEASE_KEY_ALIAS="${{ secrets.KEY_ALIAS }}" -PSKYWAY_RELEASE_KEY_PASSWORD="${{ secrets.KEY_PASSWORD }}" -PossrhUsername="${{ secrets.OSSRH_USERNAME }}" -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}" -Psigning.gnupg.keyName="${{ secrets.MAVEN_KEYID}}" publish
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,7 @@ allprojects {
     apply plugin: 'com.android.library'
     apply plugin: 'kotlin-android'
     apply plugin: 'maven-publish'
+    apply plugin: 'signing'
 
     repositories {
         google()
@@ -129,6 +130,11 @@ allprojects {
                         }
                     }
                 }
+            }
+
+            signing {
+                useGpgCmd()
+                sign publishing.publications.release
             }
         }
     }


### PR DESCRIPTION
* Use the gradle 'signing' plugin to sign the Maven artifact using a GPG key.
* Keep the aar signing with jarsigner using the Skyway java keystore.